### PR TITLE
Radiated power bug

### DIFF
--- a/py/STREAM/Settings/Equations/Ions.py
+++ b/py/STREAM/Settings/Equations/Ions.py
@@ -30,7 +30,7 @@ class Ions(DREAMIons.Ions, PrescribedParameter):
         neutral_diffusion_mode=ION_NEUTRAL_DIFFUSION_MODE_NONE, neutral_prescribed_diffusion=None, rNeutralPrescribedDiffusion=None, tNeutralPrescribedDiffusion=None,
         charged_advection_mode=ION_CHARGED_ADVECTION_MODE_NONE, charged_prescribed_advection=None, rChargedPrescribedAdvection=None, tChargedPrescribedAdvection=None,
         neutral_advection_mode=ION_NEUTRAL_ADVECTION_MODE_NONE, neutral_prescribed_advection=None, rNeutralPrescribedAdvection=None, tNeutralPrescribedAdvection=None,
-        T=None, n=None, r=None, t=None, tritium=False, hydrogen=False):
+        init_equil=False, T=None, n=None, r=None, t=None, tritium=False, hydrogen=False):
         """
         Adds a new ion species to the plasma.
 
@@ -89,7 +89,7 @@ class Ions(DREAMIons.Ions, PrescribedParameter):
                          neutral_prescribed_advection=neutral_prescribed_advection,
                          rNeutralPrescribedAdvection=rNeutralPrescribedAdvection,
                          tNeutralPrescribedAdvection=tNeutralPrescribedAdvection,
-                         T=T, n=n, r=r, t=t, interpr=self.r, interpt=None, tritium=tritium, hydrogen=hydrogen)
+                         init_equil=init_equil, T=T, n=n, r=r, t=t, interpr=self.r, interpt=None, tritium=tritium, hydrogen=hydrogen)
 
         self.ions.append(ion)
 

--- a/src/Equations/RadiatedPowerTerm.cpp
+++ b/src/Equations/RadiatedPowerTerm.cpp
@@ -62,13 +62,18 @@ using namespace STREAM;
         bool contrib = false;
         if (derivId == id_lambda_i) {
             // Rebuild weights 
-            this->SetWeights(false, jacWeights);
-            
+            real_t* ionScaleFactor = new real_t[ions->GetNzs()];
+            for (len_t iz=0; iz<GetNumberOfWeightsElements();iz++){
+                ionScaleFactor[iz]=0;
+            }
             for (len_t iz = 0; iz<ions->GetNZ(); iz++){
-                real_t dVdlambda = volumes->GetNeutralVolume_dLambdai(iz);
-
-                if (jacWeights[iz] != 0)
-                    jac->SetElement(iz, 0, jacWeights[iz] * dVdlambda / this->Volfac[iz]);
+                if (this->Volfac[iz] != 0) {
+                    real_t dVdlambda = volumes->GetNeutralVolume_dLambdai(iz);
+                    ionScaleFactor[iz] = dVdlambda / this->Volfac[iz];
+                    this->SetWeights(ionScaleFactor, jacWeights);
+                    jac->SetElement(iz, 0, jacWeights[iz]);
+                    ionScaleFactor[iz] = 0;
+                }
             }
         }
         contrib |= this->DREAM::RadiatedPowerTerm::SetJacobianBlock(uqtyId, derivId, jac, x);

--- a/src/Equations/RadiatedPowerTerm.cpp
+++ b/src/Equations/RadiatedPowerTerm.cpp
@@ -67,7 +67,7 @@ using namespace STREAM;
             for (len_t iz = 0; iz<ions->GetNZ(); iz++){
                 real_t dVdlambda = volumes->GetNeutralVolume_dLambdai(iz);
 
-                if (jacWeights[iz] > 1e-100)
+                if (jacWeights[iz] != 0)
                     jac->SetElement(iz, 0, jacWeights[iz] * dVdlambda / this->Volfac[iz]);
             }
         }

--- a/src/Equations/RadiatedPowerTerm.cpp
+++ b/src/Equations/RadiatedPowerTerm.cpp
@@ -15,6 +15,10 @@ using namespace STREAM;
 
         this->Volfac = new real_t[ionHandler->GetNzs()];
         this->jacWeights = new real_t[GetNumberOfWeightsElements()];
+        for (len_t iz=0; iz<GetNumberOfWeightsElements();iz++){
+            this->Volfac[iz]=0;
+            this->jacWeights[iz]=0;
+        }
     }
     RadiatedPowerTerm::~RadiatedPowerTerm() {
         delete [] this->jacWeights;
@@ -63,7 +67,7 @@ using namespace STREAM;
             for (len_t iz = 0; iz<ions->GetNZ(); iz++){
                 real_t dVdlambda = volumes->GetNeutralVolume_dLambdai(iz);
 
-                if (jacWeights[iz] != 0)
+                if (jacWeights[iz] > 1e-100)
                     jac->SetElement(iz, 0, jacWeights[iz] * dVdlambda / this->Volfac[iz]);
             }
         }


### PR DESCRIPTION
With jacWeights in RadiatedPowerTerm uninitialized, we sometimes get jacWeights~1e-310, while Volfac=0, meaning we divide by zero. This should be fixed now - but there might be a better way? Also, is the initialization of Volfac unnecessary?